### PR TITLE
Merging Custom Cambio Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>jboss-ejb-client</artifactId>
-    <version>4.0.20.Final</version>
+    <version>4.0.20.Final_discovery_node_selector-SNAPSHOT</version>
 
     <name>JBoss EJB client</name>
     <description>Client library for EJB applications working against Wildfly</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>jboss-ejb-client</artifactId>
-    <version>4.0.20.Final_discovery_node_selector-SNAPSHOT</version>
+    <version>4.0.20.Final_discovery_node_selector-9ae0089</version>
 
     <name>JBoss EJB client</name>
     <description>Client library for EJB applications working against Wildfly</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>jboss-ejb-client</artifactId>
-    <version>4.0.20.Final-SNAPSHOT</version>
+    <version>4.0.20.Final</version>
 
     <name>JBoss EJB client</name>
     <description>Client library for EJB applications working against Wildfly</description>

--- a/src/main/java/org/jboss/ejb/client/DiscoveryNodeSelector.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryNodeSelector.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.ejb.client;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A selector which selects and returns a node from the available nodes in a cluster to use for discovery. Typical usage of a
+ * {@link DiscoveryNodeSelector} involve load balancing of calls to various nodes in the cluster during discovery.
+ *
+ * @author Kristoffer Lundberg
+ */
+public interface DiscoveryNodeSelector {
+
+    /**
+     * Returns a node from among the {@code totalAvailableNodes}, as the target node for EJB discovery.
+     *
+     * @param clusterName         the name of the cluster to which the nodes belong (will not be {@code null})
+     * @param totalAvailableNodes all available nodes in the cluster (will not be empty or {@code null})
+     * @return the selected node name (must not be {@code null})
+     */
+    String selectNode(final String clusterName, final String[] totalAvailableNodes);
+
+    /**
+     * Always use the first available node, regardless of whether it is connected.
+     */
+    DiscoveryNodeSelector FIRST_AVAILABLE = (clusterName, totalAvailableNodes) -> totalAvailableNodes[0];
+
+    /**
+     * Use a random available node, regardless of whether it is connected.
+     */
+    DiscoveryNodeSelector RANDOM = (clusterName, totalAvailableNodes) -> totalAvailableNodes[ThreadLocalRandom.current().nextInt(totalAvailableNodes.length)];
+}

--- a/src/main/java/org/jboss/ejb/client/EJBClientCluster.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientCluster.java
@@ -31,6 +31,7 @@ public final class EJBClientCluster {
     private final long maximumConnectedNodes;
     private final long connectTimeoutMilliseconds;
     private final ClusterNodeSelector clusterNodeSelector;
+    private final DiscoveryNodeSelector discoveryNodeSelector;
     private final AuthenticationConfiguration overrideConfiguration;
 
     EJBClientCluster(final Builder builder) {
@@ -38,6 +39,7 @@ public final class EJBClientCluster {
         maximumConnectedNodes = builder.maximumConnectedNodes;
         connectTimeoutMilliseconds = builder.connectTimeoutMilliseconds;
         clusterNodeSelector = builder.clusterNodeSelector;
+        discoveryNodeSelector = builder.discoveryNodeSelector;
         overrideConfiguration = builder.overrideConfiguration;
     }
 
@@ -78,6 +80,15 @@ public final class EJBClientCluster {
     }
 
     /**
+     * Get the discovery node selector to use.
+     *
+     * @return the disvoery node selector, or {@code null} if the default selector from the context should be used
+     */
+    public DiscoveryNodeSelector getDiscoveryNodeSelector() {
+        return discoveryNodeSelector;
+    }
+
+    /**
      * Get the overriding authentication configuration in use for nodes in this cluster, overriding the caller's default.
      *
      * @return the authentication configuration to use or {@code null} to use the standard inherited authentication configuration
@@ -95,6 +106,7 @@ public final class EJBClientCluster {
         private long maximumConnectedNodes = 0;
         private long connectTimeoutMilliseconds = -1L;
         private ClusterNodeSelector clusterNodeSelector;
+        private DiscoveryNodeSelector discoveryNodeSelector;
         private AuthenticationConfiguration overrideConfiguration;
 
         /**
@@ -123,6 +135,11 @@ public final class EJBClientCluster {
 
         public Builder setClusterNodeSelector(final ClusterNodeSelector clusterNodeSelector) {
             this.clusterNodeSelector = clusterNodeSelector;
+            return this;
+        }
+
+        public Builder setDiscoveryNodeSelector(final DiscoveryNodeSelector discoveryNodeSelector) {
+            this.discoveryNodeSelector = discoveryNodeSelector;
             return this;
         }
 

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -468,6 +468,15 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
     }
 
     /**
+     * Get the initially configured cluster by the requested name for this context.
+     *
+     * @return the initially configured cluster for the requested name for this context, or null if not available.
+     */
+    public EJBClientCluster getInitialConfiguredCluster(String clusterName) {
+        return configuredClusters.get(clusterName);
+    }
+
+    /**
      * Get the maximum connected cluster nodes setting, for connection-based protocols which support eager connection.
      *
      * @return the maximum connected cluster nodes count

--- a/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
@@ -246,6 +246,10 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
         }
         // special second pass - retry everything because all were marked failed
         if (discoveryConnections && ! ok) {
+            // clear the failedDestinations cache before the retry everything as all were marked as failed.
+            if (failedDestinations != null && !failedDestinations.isEmpty())
+                failedDestinations.clear();
+            
             Logs.INVOCATION.tracef("EJB discovery provider: all discovery-enabled configured connections marked failed, retrying configured connections ...");
             for (EJBClientConnection connection : configuredConnections) {
                 if (! connection.isForDiscovery()) {


### PR DESCRIPTION
- Allow a configured DiscoveryNodeSelector for the cluster to determine the discovery node.
- Clear the failedDestinations cache before the retry